### PR TITLE
fix: add a local demo, fix COS API usage, and adopt `@types/wicg-cross-origin-storage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Most sites ship their own copy of common dependencies, and the browser re-downlo
 | [`vite-plugin-cross-origin-storage`](./packages/vite-plugin-cross-origin-storage) | The core Vite plugin: content-addressed chunking, bottom-up hashing, and the runtime loader. |
 | [`nuxt-cos`](./packages/nuxt-cos)                                                 | A thin Nuxt module wrapping the plugin.                                                      |
 
+## Demo
+
+[`demo/`](./demo) is a minimal Nuxt site using `nuxt-cos` (and, through it, `vite-plugin-cross-origin-storage`) straight from the local workspace packages. See [`demo/README.md`](./demo/README.md) for how to run it.
+
 ## Status
 
 This is exploratory. The Cross-Origin Storage API is a [WICG proposal](https://github.com/WICG/cross-origin-storage) with no native browser implementation; today it only works via the [browser extension](https://github.com/web-ai-community/cross-origin-storage-extension). Without COS the loader falls back to ordinary network requests, so builds keep working everywhere.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,36 @@
+# nuxt-cos-demo
+
+A minimal Nuxt site that uses the two packages in this monorepo from the local workspace (`workspace:*`), no published versions required:
+
+- [`nuxt-cos`](../packages/nuxt-cos) — added as a module in [`nuxt.config.ts`](./nuxt.config.ts).
+- [`vite-plugin-cross-origin-storage`](../packages/vite-plugin-cross-origin-storage) — used internally by `nuxt-cos` to do the actual chunking.
+
+## Setup
+
+From the monorepo root, build the two packages once so their `dist/` output exists:
+
+```bash
+pnpm --filter vite-plugin-cross-origin-storage build
+pnpm --filter nuxt-cos build
+```
+
+Then, from this directory:
+
+```bash
+pnpm dev
+```
+
+Note the module is a no-op in dev, so `pnpm dev` just runs a normal Nuxt app. To see Cross-Origin Storage chunking, build and preview instead:
+
+```bash
+pnpm build
+pnpm preview
+```
+
+What to look for:
+
+- `.output/public/_nuxt/` contains the managed packages (`vue`, `@vue/*`) as content-hashed chunks (64-character hex filenames).
+- View source on the page: Nuxt's default entry `<script type="module">` is replaced by a `<script id="cos-loader">` containing the loader and an inlined manifest of `cos1:<hash>` chunk references.
+- The page still server-renders and hydrates normally.
+
+Without a COS-capable browser, the loader falls back to fetching each chunk over the network, so this confirms the chunking and loader work end-to-end, but not the cross-origin sharing itself. For that, see the [nuxt-cos README](../packages/nuxt-cos/README.md#trying-it-out).

--- a/demo/app.vue
+++ b/demo/app.vue
@@ -1,0 +1,124 @@
+<template>
+  <main>
+    <h1>nuxt-cos demo</h1>
+    <p>
+      This is a plain Nuxt app using the
+      <a href="https://github.com/danielroe/cross-origin-storage/tree/main/packages/nuxt-cos">nuxt-cos</a>
+      module, which wraps
+      <a href="https://github.com/danielroe/cross-origin-storage/tree/main/packages/vite-plugin-cross-origin-storage">vite-plugin-cross-origin-storage</a>
+      to extract <code>vue</code> and <code>@vue/*</code> into content-addressed
+      <a href="https://github.com/WICG/cross-origin-storage">Cross-Origin Storage (COS)</a>
+      chunks.
+    </p>
+
+    <section class="counter">
+      <p>Vue {{ vueVersion }} is doing the rendering: count is {{ count }}</p>
+      <button @click="count++">
+        increment
+      </button>
+    </section>
+
+    <section v-if="resources.length" class="resources">
+      <h2>COS-managed resources</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Package</th>
+            <th>Hash</th>
+            <th>Chunk</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="resource in resources" :key="resource.specifier">
+            <td>{{ resource.name ?? '(unknown)' }}</td>
+            <td><code>{{ resource.hash.slice(0, 12) }}…</code></td>
+            <td><a :href="resource.href">{{ resource.file }}</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="note">
+      <p>
+        <strong>The module is a no-op in dev.</strong> To see the COS
+        chunking in action, build and preview:
+      </p>
+      <pre><code>pnpm --filter nuxt-cos-demo build
+pnpm --filter nuxt-cos-demo preview</code></pre>
+      <p>
+        Then check <code>.output/public/_nuxt/</code> for content-hashed
+        chunk files, and view source on the page: the default Nuxt entry
+        script is replaced with a <code>&lt;script id="cos-loader"&gt;</code>.
+        The table above (populated once the loader has run) shows which
+        npm package produced each chunk.
+      </p>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, version as vueVersion } from 'vue'
+import type { CosManifest } from 'vite-plugin-cross-origin-storage'
+
+useHead({
+  title: 'nuxt-cos demo',
+})
+
+const count = ref(0)
+
+const resources = ref<Array<{ specifier: string, name?: string, hash: string, file: string, href: string }>>([])
+
+onMounted(() => {
+  const manifest = (window as unknown as { __cosManifest?: CosManifest }).__cosManifest
+  if (!manifest) {
+    return
+  }
+  resources.value = Object.entries(manifest.chunks).map(([specifier, chunk]) => ({
+    specifier,
+    name: chunk.name,
+    hash: chunk.hash,
+    file: chunk.file,
+    href: manifest.base + chunk.file,
+  }))
+})
+</script>
+
+<style>
+body {
+  font-family: system-ui, sans-serif;
+  max-width: 40rem;
+  margin: 3rem auto;
+  line-height: 1.5;
+  padding: 0 1rem;
+}
+
+pre {
+  background: #f4f4f4;
+  padding: 0.75rem 1rem;
+  border-radius: 0.25rem;
+  overflow-x: auto;
+}
+
+.counter {
+  margin: 2rem 0;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 0.5rem;
+}
+
+.note {
+  color: #555;
+}
+
+.resources table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.resources th,
+.resources td {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid #ddd;
+}
+</style>

--- a/demo/nuxt.config.ts
+++ b/demo/nuxt.config.ts
@@ -1,0 +1,10 @@
+export default defineNuxtConfig({
+  modules: ['nuxt-cos'],
+  compatibilityDate: '2025-01-01',
+  cos: {
+    // Managed here explicitly (this is also the module's default), so that
+    // `@vue/*` and their dependencies are extracted into content-addressed
+    // Cross-Origin Storage chunks by vite-plugin-cross-origin-storage.
+    packages: [/^(?:vue$|@vue\/)/],
+  },
+})

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "name": "nuxt-cos-demo",
+  "type": "module",
+  "description": "Demo Nuxt site using nuxt-cos and vite-plugin-cross-origin-storage from local workspace packages",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "dependencies": {
+    "nuxt": "4.4.8",
+    "nuxt-cos": "workspace:*",
+    "vue": "3.5.39"
+  },
+  "devDependencies": {
+    "vite-plugin-cross-origin-storage": "workspace:*"
+  }
+}

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/packages/vite-plugin-cross-origin-storage/package.json
+++ b/packages/vite-plugin-cross-origin-storage/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@types/node": "latest",
+    "@types/wicg-cross-origin-storage": "2026.7.0",
     "eslint": "10.7.0",
     "hookable": "6.1.1",
     "playwright-core": "1.61.1",

--- a/packages/vite-plugin-cross-origin-storage/src/index.ts
+++ b/packages/vite-plugin-cross-origin-storage/src/index.ts
@@ -63,6 +63,20 @@ function contentSpecifier(hash: string): string {
   return `${RECIPE}:${hash}`
 }
 
+/** Recover the npm package name from a resolved module id's `node_modules` segment. */
+function packageNameFromId(id: string): string | undefined {
+  const marker = '/node_modules/'
+  const index = id.lastIndexOf(marker)
+  if (index === -1) {
+    return undefined
+  }
+  const [first, second] = id.slice(index + marker.length).split('/')
+  if (!first) {
+    return undefined
+  }
+  return first.startsWith('@') && second ? `${first}/${second}` : first
+}
+
 function toMatchers(packages: Array<string | RegExp>): RegExp[] {
   return packages.map(p => typeof p === 'string' ? new RegExp(`^${p}$`) : p)
 }
@@ -300,7 +314,7 @@ export function cosPlugin(options: CosPluginOptions): Plugin {
         const hash = createHash('sha256').update(resolved).digest('hex')
         const fileName = `${assetPrefix}${hash}.js`
         hashes.set(id, hash)
-        managed[contentSpecifier(hash)] = { file: `${hash}.js`, hash }
+        managed[contentSpecifier(hash)] = { file: `${hash}.js`, hash, name: packageNameFromId(id) }
         this.emitFile({ type: 'asset', fileName, source: resolved })
         return hash
       }

--- a/packages/vite-plugin-cross-origin-storage/src/loader.ts
+++ b/packages/vite-plugin-cross-origin-storage/src/loader.ts
@@ -1,17 +1,28 @@
 declare global {
+  interface CrossOriginStorageRequestFileHandleHash {
+    value: string
+    algorithm: string
+  }
+
+  interface CrossOriginStorageRequestFileHandleOptions {
+    create?: boolean
+    origins?: string[] | string
+  }
+
+  interface CrossOriginStorageManager {
+    requestFileHandle: (
+      hash: CrossOriginStorageRequestFileHandleHash,
+      options?: CrossOriginStorageRequestFileHandleOptions,
+    ) => Promise<FileSystemFileHandle>
+  }
+
   interface Navigator {
-    crossOriginStorage?: {
-      requestFileHandles: (
-        descriptors: Array<{ algorithm: string, value: string }>,
-        options?: { create?: boolean },
-      ) => Promise<Array<{
-        getFile: () => Promise<File>
-        createWritable: () => Promise<{
-          write: (data: Blob) => Promise<void>
-          close: () => Promise<void>
-        }>
-      }>>
-    }
+    readonly crossOriginStorage?: CrossOriginStorageManager
+  }
+
+  interface Window {
+    /** The manifest the loader ran with, exposed for introspection (e.g. devtools, demo UIs). */
+    __cosManifest?: CosManifest
   }
 }
 
@@ -23,11 +34,17 @@ export interface CosManifest {
    * loaded straight from the network rather than stored in COS by a content hash.
    */
   entry: { specifier: string, file: string }
-  /** Map of content-addressed specifier to `{ file, hash }` for every COS-managed chunk. */
-  chunks: Record<string, { file: string, hash: string }>
+  /**
+   * Map of content-addressed specifier to `{ file, hash, name }` for every COS-managed chunk.
+   * `name` is the npm package the chunk was bundled from (e.g. `vue`, `@vue/reactivity`), when
+   * it could be derived from the resolved module path; absent for chunks it couldn't be.
+   */
+  chunks: Record<string, { file: string, hash: string, name?: string }>
 }
 
 export async function runCosLoader(manifest: CosManifest): Promise<void> {
+  window.__cosManifest = manifest
+
   const cos = navigator.crossOriginStorage
   const imports: Record<string, string> = {}
 
@@ -41,11 +58,9 @@ export async function runCosLoader(manifest: CosManifest): Promise<void> {
   async function resolveChunk(hash: string, file: string): Promise<string> {
     if (cos) {
       try {
-        const [handle] = await enqueue(() => cos.requestFileHandles([{ algorithm: 'SHA-256', value: hash }]))
-        if (handle) {
-          const blob = await handle.getFile()
-          return URL.createObjectURL(new Blob([blob], { type: 'text/javascript' }))
-        }
+        const handle = await enqueue(() => cos.requestFileHandle({ algorithm: 'SHA-256', value: hash }))
+        const blob = await handle.getFile()
+        return URL.createObjectURL(new Blob([blob], { type: 'text/javascript' }))
       }
       catch (error) {
         if ((error as Error)?.name !== 'NotFoundError') {
@@ -67,12 +82,10 @@ export async function runCosLoader(manifest: CosManifest): Promise<void> {
     if (cos) {
       try {
         await enqueue(async () => {
-          const [handle] = await cos.requestFileHandles([{ algorithm: 'SHA-256', value: hash }], { create: true })
-          if (handle) {
-            const writable = await handle.createWritable()
-            await writable.write(blob)
-            await writable.close()
-          }
+          const handle = await cos.requestFileHandle({ algorithm: 'SHA-256', value: hash }, { create: true, origins: '*' })
+          const writable = await handle.createWritable()
+          await writable.write(blob)
+          await writable.close()
         })
       }
       catch (error) {

--- a/packages/vite-plugin-cross-origin-storage/src/loader.ts
+++ b/packages/vite-plugin-cross-origin-storage/src/loader.ts
@@ -1,25 +1,6 @@
+/// <reference types="wicg-cross-origin-storage" />
+
 declare global {
-  interface CrossOriginStorageRequestFileHandleHash {
-    value: string
-    algorithm: string
-  }
-
-  interface CrossOriginStorageRequestFileHandleOptions {
-    create?: boolean
-    origins?: string[] | string
-  }
-
-  interface CrossOriginStorageManager {
-    requestFileHandle: (
-      hash: CrossOriginStorageRequestFileHandleHash,
-      options?: CrossOriginStorageRequestFileHandleOptions,
-    ) => Promise<FileSystemFileHandle>
-  }
-
-  interface Navigator {
-    readonly crossOriginStorage?: CrossOriginStorageManager
-  }
-
   interface Window {
     /** The manifest the loader ran with, exposed for introspection (e.g. devtools, demo UIs). */
     __cosManifest?: CosManifest

--- a/packages/vite-plugin-cross-origin-storage/test/types.test-d.ts
+++ b/packages/vite-plugin-cross-origin-storage/test/types.test-d.ts
@@ -41,7 +41,7 @@ describe('CosManifest', () => {
     expectTypeOf<CosManifest>().toEqualTypeOf<{
       base: string
       entry: { specifier: string, file: string }
-      chunks: Record<string, { file: string, hash: string }>
+      chunks: Record<string, { file: string, hash: string, name?: string }>
     }>()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@types/node':
         specifier: latest
         version: 26.1.1
+      '@types/wicg-cross-origin-storage':
+        specifier: 2026.7.0
+        version: 2026.7.0
       eslint:
         specifier: 10.7.0
         version: 10.7.0(jiti@2.7.0)
@@ -2065,6 +2068,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/wicg-cross-origin-storage@2026.7.0':
+    resolution: {integrity: sha512-9+df+iRT0q1avCNSq2jUPZM00Qj6mFMejg/DgvIplY77QaHYlXZzoRw/R8vJ5hyx42Xe9MHH/cVIG31eSH0dqw==}
 
   '@typescript-eslint/eslint-plugin@8.62.0':
     resolution: {integrity: sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==}
@@ -7056,6 +7062,8 @@ snapshots:
       undici-types: 8.3.0
 
   '@types/resolve@1.20.2': {}
+
+  '@types/wicg-cross-origin-storage@2026.7.0': {}
 
   '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.7.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,22 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  demo:
+    dependencies:
+      nuxt:
+        specifier: 4.4.8
+        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@26.1.1)(@vue/compiler-sfc@3.5.39)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.17)(terser@5.48.0)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt-cos:
+        specifier: workspace:*
+        version: link:../packages/nuxt-cos
+      vue:
+        specifier: 3.5.39
+        version: 3.5.39(typescript@6.0.3)
+    devDependencies:
+      vite-plugin-cross-origin-storage:
+        specifier: workspace:*
+        version: link:../packages/vite-plugin-cross-origin-storage
+
   packages/nuxt-cos:
     dependencies:
       '@nuxt/kit':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,6 @@ allowBuilds:
   '@parcel/watcher': false
   esbuild: false
   unrs-resolver: false
+
+minimumReleaseAgeExclude:
+  - '@types/wicg-cross-origin-storage@2026.7.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - packages/*
+  - demo
 
 allowBuilds:
   '@parcel/watcher': false


### PR DESCRIPTION
## Summary
- Adds `demo/` — a minimal Nuxt site using `nuxt-cos` (and, through it, `vite-plugin-cross-origin-storage`) directly from the local workspace packages, with a page listing the COS-managed resources (package name, content hash, chunk file).
- Fixes `loader.ts` to use the WICG spec's singular `requestFileHandle()` API instead of the deprecated plural `requestFileHandles()`, and sets `origins: '*'` on writes.
- Adds a `name` field to each manifest chunk entry, recording which npm package it was bundled from, and exposes the manifest on `window.__cosManifest` for introspection.
- Replaces the handwritten Cross-Origin Storage ambient type declarations with a reference to the newly published `@types/wicg-cross-origin-storage` (DefinitelyTyped/DefinitelyTyped#75200).

## Test plan
- [x] `pnpm --filter vite-plugin-cross-origin-storage build` and `test` (unit + type tests) pass
- [x] `pnpm --filter nuxt-cos build`
- [x] `pnpm --filter nuxt-cos-demo build && node .output/server/index.mjs` — verified content-hashed chunks, injected `cos-loader` script, and the resources table render correctly
- [x] `pnpm --filter nuxt-cos-demo dev` — confirmed the module is a no-op in dev as documented