### PR TITLE
fix(nuxt): respect custom build assets dir

### DIFF
--- a/packages/nuxt-cos/src/module.ts
+++ b/packages/nuxt-cos/src/module.ts
@@ -1,5 +1,6 @@
 import { defineNuxtModule, addServerPlugin, addVitePlugin, createResolver } from '@nuxt/kit'
 import { cosPlugin } from 'vite-plugin-cross-origin-storage'
+import { resolveBuildAssetsBase } from './runtime/utils/assets-base'
 
 export interface ModuleOptions {
   /**
@@ -32,12 +33,15 @@ export default defineNuxtModule<ModuleOptions>({
 
     addServerPlugin(resolver.resolve('./runtime/server/plugins/inject'))
 
-    addVitePlugin(() => cosPlugin({
-      packages: options.packages,
-      base: '/_nuxt/',
-      onGenerated: (content) => {
-        scriptContent = content
-      },
-    }), { client: true, server: false })
+    addVitePlugin(() => {
+      const assetsBase = resolveBuildAssetsBase(nuxt.options.app)
+      return cosPlugin({
+        packages: options.packages,
+        base: assetsBase,
+        onGenerated: (content) => {
+          scriptContent = content
+        },
+      })
+    }, { client: true, server: false })
   },
 })

--- a/packages/nuxt-cos/src/runtime/server/plugins/inject.ts
+++ b/packages/nuxt-cos/src/runtime/server/plugins/inject.ts
@@ -1,15 +1,32 @@
 import type { NitroApp } from 'nitropack/types'
+import { useRuntimeConfig } from '#imports'
 import scriptContent from 'virtual:cos-loader'
+import { resolveBuildAssetsBase } from '../../utils/assets-base'
 
-const ENTRY_MODULE_SCRIPT_RE = /<script\s(?=[^>]*(?<![\w-])type="module")(?=[^>]*(?<![\w-])src="\/_nuxt\/[^"]*")[^>]+><\/script>/g
-const NUXT_PRELOAD_LINK_RE = /<link\s(?=[^>]*(?<![\w-])rel="(?:modulepreload|prefetch)")(?=[^>]*(?<![\w-])href="\/_nuxt\/[^"]*")[^>]+>/g
+function entryModuleScriptRe(assetsBase: string): RegExp {
+  // /<script\s(?=[^>]*(?<![\w-])type="module")(?=[^>]*(?<![\w-])src="\/_nuxt\/[^"]*")[^>]+><\/script>/g
+  return new RegExp(
+    `<script\\s(?=[^>]*(?<![\\w-])type="module")(?=[^>]*(?<![\\w-])src="${assetsBase}[^"]*")[^>]+><\\/script>`,
+    'g',
+  )
+}
+
+function nuxtPreloadLinkRe(assetsBase: string): RegExp {
+  //  /<link\s(?=[^>]*(?<![\w-])rel="(?:modulepreload|prefetch)")(?=[^>]*(?<![\w-])href="\/_nuxt\/[^"]*")[^>]+>/gÒ
+  return new RegExp(
+    `<link\\s(?=[^>]*(?<![\\w-])rel="(?:modulepreload|prefetch)")(?=[^>]*(?<![\\w-])href="${assetsBase}[^"]*")[^>]+>`,
+    'g',
+  )
+}
 
 export default (nitroApp: NitroApp) => {
   nitroApp.hooks.hook('render:html', (ctx) => {
+    const assetsBase = resolveBuildAssetsBase(useRuntimeConfig().app)
+    const entryRe = entryModuleScriptRe(assetsBase)
+    const preloadRe = nuxtPreloadLinkRe(assetsBase)
+
     ctx.head = ctx.head.map(chunk =>
-      chunk
-        .replace(ENTRY_MODULE_SCRIPT_RE, '')
-        .replace(NUXT_PRELOAD_LINK_RE, ''),
+      chunk.replace(entryRe, '').replace(preloadRe, ''),
     )
     ctx.head.push(`<script id="cos-loader">${scriptContent}</script>`)
   })

--- a/packages/nuxt-cos/src/runtime/utils/assets-base.ts
+++ b/packages/nuxt-cos/src/runtime/utils/assets-base.ts
@@ -1,0 +1,15 @@
+export interface BuildAssetsAppConfig {
+  baseURL?: string
+  buildAssetsDir: string
+  cdnURL?: string
+}
+
+export function resolveBuildAssetsBase(app: BuildAssetsAppConfig): string {
+  const publicBase = app.cdnURL || app.baseURL || '/'
+  if (publicBase.includes('://')) {
+    const url = new URL(publicBase)
+    url.pathname = app.buildAssetsDir
+    return url.href
+  }
+  return app.buildAssetsDir
+}

--- a/packages/nuxt-cos/test/assets-base.test.ts
+++ b/packages/nuxt-cos/test/assets-base.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { resolveBuildAssetsBase } from '../src/runtime/utils/assets-base'
+
+describe('resolveBuildAssetsBase', () => {
+  it('joins baseURL with buildAssetsDir', () => {
+    expect(resolveBuildAssetsBase({
+      baseURL: '/',
+      buildAssetsDir: '/cms/_nuxt/',
+    })).toBe('/cms/_nuxt/')
+  })
+
+  it('uses cdnURL over baseURL when set', () => {
+    expect(resolveBuildAssetsBase({
+      baseURL: '/',
+      buildAssetsDir: '/_nuxt/',
+      cdnURL: 'https://cdn.example.com/',
+    })).toBe('https://cdn.example.com/_nuxt/')
+  })
+
+  it('defaults public base to /', () => {
+    expect(resolveBuildAssetsBase({
+      buildAssetsDir: '/_nuxt/',
+    })).toBe('/_nuxt/')
+  })
+})


### PR DESCRIPTION
Fixes #15 

**Problem:** 
currently in nuxt-cos/src/module.ts & nuxt-cos/src/runtime/server/plugins/inject.ts the assets path is hardcoded `/_nuxt` and not using the nuxt app config.

**Suggested solution:**
* In utils, add a function resolveBuildAssetsBase reading the config (cdnUrl, baseUrl, buildAssetsDir)
* Use resolveBuildAssetsBase in inject.ts and module.ts 

I tested this fix in our app facing the issue and link the fixed module locally and it seems to be OK now:
<img width="1986" height="1308" alt="image" src="https://github.com/user-attachments/assets/f98d885a-e53f-4b26-ba2f-250ac2d1ac81" />

❤️ Friendly reminder, if you are on holidays -> you are on holidays 😉 This ~~should~~ **must** wait.